### PR TITLE
5 aci id support

### DIFF
--- a/common/include/ads/ads.h
+++ b/common/include/ads/ads.h
@@ -23,6 +23,7 @@ typedef struct aurora_discovery_service_conf ads_conf_t;
 struct aurora_discovery_service_exchange_data {
     aurora_blob_t comm;
     aurora_blob_t notif;
+    aurora_blob_t config;
 };
 
 struct aurora_discovery_service_conf {

--- a/common/include/common_types.h
+++ b/common/include/common_types.h
@@ -13,6 +13,7 @@
 #define _COMMON_TYPES_H_
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 typedef struct {

--- a/common/include/operating_configuration.h
+++ b/common/include/operating_configuration.h
@@ -18,16 +18,55 @@
 #include <string.h>
 
 struct aurora_operating_configuration {
+    uint64_t rank;
     struct {
-        int64_t group;
-        uint64_t rank;
-    } id;
+        uint64_t id;
+        int64_t size;
+    } group;
 
     struct {
         char *persistent_path;
         bool use_error_correction;
     } chkpt_opts;
 };
+
+typedef struct aurora_operating_configuration opconf_t;
+
+static inline opconf_t *aoc_alloc(char *persistent_path) {
+    if (!persistent_path) {
+        return NULL;
+    }
+
+    size_t strsize = strlen(persistent_path) + 1;
+    size_t structsize = sizeof(opconf_t);
+    uint8_t *structbuf = malloc(strsize + structsize);
+
+    if (!structbuf) {
+        // ERROR: Bad Alloc??
+        return NULL;
+    }
+
+    opconf_t *pConfig = (void *) structbuf;
+    pConfig->chkpt_opts.persistent_path = (void *) (structbuf + structsize);
+
+    pConfig->group.id = 0;
+    pConfig->group.size = -1;
+    pConfig->rank = 0;
+
+    strcpy(pConfig->chkpt_opts.persistent_path, persistent_path);
+
+    return pConfig;
+}
+
+static inline void aoc_free(struct aurora_operating_configuration **ppConfig) {
+    if (ppConfig) {
+        if (*ppConfig) {
+            (*ppConfig)->chkpt_opts.persistent_path = NULL;
+            free(*ppConfig);
+            *ppConfig = NULL;
+        }
+    }
+}
 
 static inline size_t aoc_size(
     const struct aurora_operating_configuration *pConfig) {
@@ -37,59 +76,9 @@ static inline size_t aoc_size(
     size_t size = 0;
     size += sizeof(struct aurora_operating_configuration);
     if (pConfig->chkpt_opts.persistent_path) {
-        size += strlen(pConfig->chkpt_opts.persistent_path);
+        size += strlen(pConfig->chkpt_opts.persistent_path) + 1;
     }
     return size;
-}
-
-static inline void *aoc_pack(
-    const struct aurora_operating_configuration *pConfig) {
-    if (!pConfig) {
-        return NULL;
-    }
-    uint8_t *buffer = malloc(aoc_size(pConfig));
-    if (!buffer) {
-        return NULL;
-    }
-    (void) memcpy(buffer, pConfig,
-                  sizeof(struct aurora_operating_configuration));
-    if (pConfig->chkpt_opts.persistent_path) {
-        strcpy((char *) buffer + sizeof(struct aurora_operating_configuration),
-               pConfig->chkpt_opts.persistent_path);
-    }
-    return buffer;
-}
-
-static inline struct aurora_operating_configuration *aoc_unpack(
-    const void *buffer, size_t size) {
-    if (!buffer || size == 0) {
-        return NULL;
-    }
-    struct aurora_operating_configuration *pConfig =
-        malloc(sizeof(struct aurora_operating_configuration));
-
-    if (!pConfig) {
-        return NULL;
-    }
-
-    (void) memcpy(pConfig, buffer,
-                  sizeof(struct aurora_operating_configuration));
-
-    pConfig->chkpt_opts.persistent_path = NULL;
-
-    if (size > sizeof(struct aurora_operating_configuration)) {
-        size_t str_len = size - sizeof(struct aurora_operating_configuration);
-        pConfig->chkpt_opts.persistent_path = malloc(str_len);
-        if (!pConfig->chkpt_opts.persistent_path) {
-            free(pConfig);
-            return NULL;
-        }
-        (void)memcpy(pConfig->chkpt_opts.persistent_path,
-               (char *) buffer + sizeof(struct aurora_operating_configuration),
-               str_len);
-    }
-
-    return pConfig;
 }
 
 #endif

--- a/common/include/operating_configuration.h
+++ b/common/include/operating_configuration.h
@@ -1,0 +1,95 @@
+/**
+ * @file operating_configuration.h
+ * @author Jacob Chisholm (https://Jchisholm204.github.io)
+ * @brief Defines the Operation Mode Configuration for AURORA
+ * @version 0.1
+ * @date Created: 2026-03-31
+ * @modified Last Modified: 2026-03-31
+ *
+ * @copyright Copyright (c) 2026
+ */
+
+#ifndef _OPERATING_CONFIGURATION_H_
+#define _OPERATING_CONFIGURATION_H_
+#include <malloc.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+struct aurora_operating_configuration {
+    struct {
+        int64_t group;
+        uint64_t rank;
+    } id;
+
+    struct {
+        char *persistent_path;
+        bool use_error_correction;
+    } chkpt_opts;
+};
+
+static inline size_t aoc_size(
+    const struct aurora_operating_configuration *pConfig) {
+    if (!pConfig) {
+        return 0;
+    }
+    size_t size = 0;
+    size += sizeof(struct aurora_operating_configuration);
+    if (pConfig->chkpt_opts.persistent_path) {
+        size += strlen(pConfig->chkpt_opts.persistent_path);
+    }
+    return size;
+}
+
+static inline void *aoc_pack(
+    const struct aurora_operating_configuration *pConfig) {
+    if (!pConfig) {
+        return NULL;
+    }
+    uint8_t *buffer = malloc(aoc_size(pConfig));
+    if (!buffer) {
+        return NULL;
+    }
+    (void) memcpy(buffer, pConfig,
+                  sizeof(struct aurora_operating_configuration));
+    if (pConfig->chkpt_opts.persistent_path) {
+        strcpy((char *) buffer + sizeof(struct aurora_operating_configuration),
+               pConfig->chkpt_opts.persistent_path);
+    }
+    return buffer;
+}
+
+static inline struct aurora_operating_configuration *aoc_unpack(
+    const void *buffer, size_t size) {
+    if (!buffer || size == 0) {
+        return NULL;
+    }
+    struct aurora_operating_configuration *pConfig =
+        malloc(sizeof(struct aurora_operating_configuration));
+
+    if (!pConfig) {
+        return NULL;
+    }
+
+    (void) memcpy(pConfig, buffer,
+                  sizeof(struct aurora_operating_configuration));
+
+    pConfig->chkpt_opts.persistent_path = NULL;
+
+    if (size > sizeof(struct aurora_operating_configuration)) {
+        size_t str_len = size - sizeof(struct aurora_operating_configuration);
+        pConfig->chkpt_opts.persistent_path = malloc(str_len);
+        if (!pConfig->chkpt_opts.persistent_path) {
+            free(pConfig);
+            return NULL;
+        }
+        (void)memcpy(pConfig->chkpt_opts.persistent_path,
+               (char *) buffer + sizeof(struct aurora_operating_configuration),
+               str_len);
+    }
+
+    return pConfig;
+}
+
+#endif

--- a/common/src/ads/ads.c
+++ b/common/src/ads/ads.c
@@ -141,51 +141,85 @@ extern ads_exchange_data_t *ads_exchange(int sock_fd,
     send(sock_fd, pTxData, sizeof(ads_exchange_data_t), 0);
     send(sock_fd, pTxData->comm.data, pTxData->comm.size, 0);
     send(sock_fd, pTxData->notif.data, pTxData->notif.size, 0);
+    send(sock_fd, pTxData->config.data, pTxData->config.size, 0);
 
     ads_exchange_data_t *pRx = malloc(sizeof(ads_exchange_data_t));
     if (!pRx) {
         log_error("Failed to allocate RX buffer");
         return NULL;
     }
-    ssize_t rx_bytes = 0;
-    rx_bytes = recv(sock_fd, pRx, sizeof(ads_exchange_data_t), MSG_WAITALL);
-    if (rx_bytes != sizeof(ads_exchange_data_t)) {
-        log_error("Failed to correctly recv header");
-    }
+
+    { // BEGIN Exchange header struct
+        ssize_t rx_bytes = 0;
+        rx_bytes = recv(sock_fd, pRx, sizeof(ads_exchange_data_t), MSG_WAITALL);
+        if (rx_bytes != sizeof(ads_exchange_data_t)) {
+            log_error("Failed to correctly recv header");
+        }
+    } // END Exchange header struct
 
     // Ensure the pointers are zeroed
     pRx->comm.data = NULL;
     pRx->notif.data = NULL;
 
     // Recv exchange data
-    pRx->comm.data = malloc(pRx->comm.size);
-    if (!pRx->comm.data) {
-        log_error("Failed to allocate comm key recv buffer");
-        free(pRx);
-        return NULL;
-    }
-    rx_bytes = recv(sock_fd, pRx->comm.data, pRx->comm.size, MSG_WAITALL);
-    if (rx_bytes != (ssize_t) pRx->comm.size) {
-        log_error("Failed to correctly recv header");
-        free(pRx->comm.data);
-        free(pRx);
-        return NULL;
-    }
-    pRx->notif.data = malloc(pRx->notif.size);
-    if (!pRx->notif.data) {
-        log_error("Failed to allocate user data recv buffer");
-        free(pRx->comm.data);
-        free(pRx);
-        return NULL;
-    }
-    rx_bytes = recv(sock_fd, pRx->notif.data, pRx->notif.size, MSG_WAITALL);
-    if (rx_bytes != (ssize_t) pRx->notif.size) {
-        log_error("Failed to correctly recv header");
-        free(pRx->comm.data);
-        free(pRx->notif.data);
-        free(pRx);
-        return NULL;
-    }
+    { // BEGIN Comms Exchange
+        pRx->comm.data = malloc(pRx->comm.size);
+        if (!pRx->comm.data) {
+            log_error("Failed to allocate comm key recv buffer");
+            free(pRx);
+            return NULL;
+        }
+        ssize_t rx_bytes =
+            recv(sock_fd, pRx->comm.data, pRx->comm.size, MSG_WAITALL);
+        if (rx_bytes != (ssize_t) pRx->comm.size) {
+            log_error("Failed to correctly recv header");
+            free(pRx->comm.data);
+            free(pRx);
+            return NULL;
+        }
+    } // END Comms Exchange
+
+    { // BEGIN Notification keys exchange
+        pRx->notif.data = malloc(pRx->notif.size);
+        if (!pRx->notif.data) {
+            log_error("Failed to allocate user data recv buffer");
+            free(pRx->comm.data);
+            free(pRx);
+            return NULL;
+        }
+
+        ssize_t rx_bytes =
+            recv(sock_fd, pRx->notif.data, pRx->notif.size, MSG_WAITALL);
+        if (rx_bytes != (ssize_t) pRx->notif.size) {
+            log_error("Failed to correctly recv header");
+            free(pRx->comm.data);
+            free(pRx->notif.data);
+            free(pRx);
+            return NULL;
+        }
+    } // END Notification keys exchange
+
+    { // BEGIN Config Exchange
+        pRx->config.data = malloc(pRx->config.size);
+        if (!pRx->config.data) {
+            log_error("Failed to allocate user data recv buffer");
+            free(pRx->comm.data);
+            free(pRx->notif.data);
+            free(pRx);
+            return NULL;
+        }
+
+        ssize_t rx_bytes =
+            recv(sock_fd, pRx->config.data, pRx->config.size, MSG_WAITALL);
+        if (rx_bytes != (ssize_t) pRx->config.size) {
+            log_error("Failed to correctly recv header");
+            free(pRx->comm.data);
+            free(pRx->notif.data);
+            free(pRx->config.data);
+            free(pRx);
+            return NULL;
+        }
+    } // END Notification keys exchange
 
     close(sock_fd);
 

--- a/lib/include/aul.h
+++ b/lib/include/aul.h
@@ -21,7 +21,7 @@
 #define AUL_NAME_LEN 16
 #endif
 
-int AUL_Init(const aul_configuration_t *pCFG, const uint64_t proc_id);
+int AUL_Init(const aul_configuration_t *pCFG);
 
 int AUL_Finalize(void);
 

--- a/lib/include/aul_configuration.h
+++ b/lib/include/aul_configuration.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 // Aurora Connection Mode
 enum eAULConnMode {
@@ -27,10 +28,20 @@ enum eAULConnMode {
 };
 
 typedef struct {
+    // MPI
+    uint64_t rank;
+    uint64_t opt_group_id;
+    int64_t opt_group_size;
+
+    // Checkpointing
     char *persistent_path;
     bool use_error_correction;
+
+    // Connection
     enum eAULConnMode connection_mode;
     char *opt_ip;
+
+    // Logging
     char *opt_log_file;
 } aul_configuration_t;
 

--- a/lib/include/aul_internal.h
+++ b/lib/include/aul_internal.h
@@ -18,6 +18,7 @@
 #include "arm/arm.h"
 #include "aul.h"
 #include "aul_configuration.h"
+#include "operating_configuration.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,6 +29,7 @@ struct aurora_user_library_context {
     aci_hndl *pACI;
     acn_hndl *pACN;
     arm_hndl *pARM;
+    struct aurora_operating_configuration *pConfig;
 };
 
 extern struct aurora_user_library_context _aul_ctx;

--- a/lib/src/aul.c
+++ b/lib/src/aul.c
@@ -28,6 +28,7 @@ struct aurora_user_library_context _aul_ctx = {
     .pACI = NULL,
     .pACN = NULL,
     .pARM = NULL,
+    .pConfig = NULL,
 };
 
 void _arm_free(const amr_hndl *const pAMR) {
@@ -38,7 +39,7 @@ void _arm_free(const amr_hndl *const pAMR) {
     }
 }
 
-int AUL_Init(const aul_configuration_t *pCFG, const uint64_t proc_id) {
+int AUL_Init(const aul_configuration_t *pCFG) {
     if (!pCFG) {
         log_error("No Configuration Provided");
         return -1;
@@ -59,20 +60,50 @@ int AUL_Init(const aul_configuration_t *pCFG, const uint64_t proc_id) {
     log_trace("\tCon Mode: %d", pCFG->connection_mode);
     log_trace("\tOpt IP: %s", pCFG->opt_ip);
     log_trace("\tLog File: %s", pCFG->opt_log_file);
-    log_trace("\tPID: %d", proc_id);
+    log_trace("\tRank: %d", pCFG->rank);
+    log_trace("\tOpt GID: %d", pCFG->opt_group_id);
+    log_trace("\tOpt GSize: %d", pCFG->opt_group_size);
+
+    _aul_ctx.pConfig = aoc_alloc(pCFG->persistent_path);
+    if (!_aul_ctx.pConfig) {
+        log_error("Configuration Failed");
+        if (_aul_ctx.log_file) {
+            fclose(_aul_ctx.log_file);
+            _aul_ctx.log_file = NULL;
+        }
+        return -2;
+    }
+
+    _aul_ctx.pConfig->rank = pCFG->rank;
+    _aul_ctx.pConfig->group.id = pCFG->opt_group_id;
+    _aul_ctx.pConfig->group.size = pCFG->opt_group_size;
+    _aul_ctx.pConfig->group.size = pCFG->opt_group_size;
+    _aul_ctx.pConfig->chkpt_opts.use_error_correction =
+        pCFG->use_error_correction;
 
     ads_exchange_data_t ads_data_tx = {0};
+
+    // Pack Configuration Data
+    ads_data_tx.config.data = _aul_ctx.pConfig;
+    ads_data_tx.config.size = aoc_size(_aul_ctx.pConfig);
+    if (!ads_data_tx.config.data) {
+        log_fatal("Bad Alloc??");
+        AUL_Finalize();
+        return -1;
+    }
 
     // Initialize ACI
     _aul_ctx.pACI = aci_create_instance(&ads_data_tx.comm);
     if (!_aul_ctx.pACI) {
         log_fatal("Could not create the ACI instance");
+        AUL_Finalize();
         return -1;
     }
     // Initialize ACN
     _aul_ctx.pACN = acn_create_instance(_aul_ctx.pACI, &ads_data_tx.notif);
     if (!_aul_ctx.pACN) {
         log_fatal("Could not create the ACN instance");
+        AUL_Finalize();
         return -1;
     }
 
@@ -157,6 +188,8 @@ int AUL_Finalize(void) {
         fclose(_aul_ctx.log_file);
         _aul_ctx.log_file = NULL;
     }
+    // All handlers placed here must be able to handle a hardfault
+    aoc_free(&_aul_ctx.pConfig);
     arm_destroy_instance(&_aul_ctx.pARM);
     acn_destroy_instance(&_aul_ctx.pACN);
     aci_destroy_instance(&_aul_ctx.pACI);

--- a/lib/src/aul_configuration.c
+++ b/lib/src/aul_configuration.c
@@ -12,6 +12,9 @@
 #include "aul_configuration.h"
 
 const aul_configuration_t AUL_CONFIG_DEFAULT = {
+    .rank = 0,
+    .opt_group_id = 0,
+    .opt_group_size = -1,
     .persistent_path = "./checkpoints",
     .use_error_correction = false,
     .connection_mode = eAULCModeAuto,

--- a/server/include/aim.h
+++ b/server/include/aim.h
@@ -15,6 +15,7 @@
 #include "aci/aci.h"
 #include "acn/acn.h"
 #include "arm/arm.h"
+#include "operating_configuration.h"
 
 #include <stdalign.h>
 #include <stdatomic.h>
@@ -27,6 +28,7 @@ struct aurora_instance_manager_entry {
     aci_hndl *pACI;
     acn_hndl *pACN;
     arm_hndl *pARM;
+    struct aurora_operating_configuration *pConfig;
     union {
 #ifdef AIM_INTERNAL
         struct {

--- a/server/src/acl.c
+++ b/server/src/acl.c
@@ -68,7 +68,7 @@ int acl_finalize(acl_hndl **ppHndl) {
     }
     (*ppHndl)->running = false;
     pthread_join((*ppHndl)->thread_manager, NULL);
-    (void)ads_finalize(&(*ppHndl)->pADS);
+    (void) ads_finalize(&(*ppHndl)->pADS);
     free(*ppHndl);
     *ppHndl = NULL;
     return 0;
@@ -188,6 +188,28 @@ void *_acl_connection_accept(void *arg) {
         aim_remove_entry(pCtx->pAIM, pCli);
         free(pCtx);
         return NULL;
+    }
+
+    pCli->pConfig = ads_data_rx->config.data;
+
+    if (!pCli->pConfig || ads_data_rx->config.size == sizeof(opconf_t)) {
+        log_error("No/Invalid Configuration??");
+        acn_destroy_instance(&pCli->pACN);
+        aci_destroy_instance(&pCli->pACI);
+        pCli->pConfig = NULL;
+        aim_remove_entry(pCtx->pAIM, pCli);
+        free(pCtx);
+        return NULL;
+    }
+
+    else {
+        pCli->pConfig->chkpt_opts.persistent_path =
+            (char *) ((uint8_t *) pCli->pConfig) + sizeof(opconf_t);
+
+        log_debug("rank=%d", pCli->pConfig->rank);
+        log_debug("group_id=%d", pCli->pConfig->group.id);
+        log_debug("group_size=%d", pCli->pConfig->group.size);
+        log_debug("path=%s", pCli->pConfig->chkpt_opts.persistent_path);
     }
 
     aim_enqueue(pCtx->pAIM, pCli);

--- a/server/src/acr.c
+++ b/server/src/acr.c
@@ -146,7 +146,7 @@ void *_acr_checkpoint(void *arg) {
 
     char name[ACN_NAME_LEN];
     int64_t version;
-    acn_get(pInstance->pACN, eACN_version, &version);
+    acn_get(pInstance->pACN, eACN_version, (uint64_t *) &version);
     acn_get_name(pCtx->pInstance->pACN, name);
 
     log_debug("checkpoint: %d %.*s", version, ACN_NAME_LEN, name);

--- a/tests/discovery/test_discovery.c
+++ b/tests/discovery/test_discovery.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     (void) argv;
 
     aul_configuration_t cfg = AUL_CONFIG_DEFAULT;
-    AUL_Init(&cfg, 0);
+    AUL_Init(&cfg);
 
     printf("AUL Initialized\n");
 
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
     printf("Starting Checkpoint\n");
     // *nowarn*
-    int s = AUL_Checkpoint(1, "TestCkpt");
+    int s = AUL_Checkpoint(1, "TestCkpt0000000");
     printf("Finished Checkpoint status=%d\n", s);
 
     for (int i = 0; i < MEM_SIZE; i++) {
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
 
     printf("Starting Restore\n");
     // *nowarn*
-    int v = AUL_Restart(-1, "TestRestore");
+    int v = AUL_Restart(-1, "TestRestore0000");
     printf("Finished Restore latest version=%d\n", v);
 
     for (int i = 0; i < MEM_SIZE; i++) {
@@ -54,7 +54,6 @@ int main(int argc, char **argv) {
             printf("Error: 0x%lx != 0x%lx\n", buf[i], bu2[i]);
         }
     }
-
 
     AUL_Finalize();
 


### PR DESCRIPTION
Closes #5 #7 

Rather than making the configuration part of the ACI, make it part of the generic high-level structure and have it funneled through the initial exchange.